### PR TITLE
Added DMX consumer and a UDP Heartbeat service

### DIFF
--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -7,6 +7,8 @@ add_subdirectory(oal)
 add_subdirectory(decklink)
 add_subdirectory(screen)
 add_subdirectory(newtek)
+add_subdirectory(dmx)
+
 if (ENABLE_HTML)
 	add_subdirectory(html)
 endif ()

--- a/src/modules/dmx/CMakeLists.txt
+++ b/src/modules/dmx/CMakeLists.txt
@@ -22,6 +22,7 @@ target_include_directories(dmx PRIVATE
     ..
     ../..
     ${BOOST_INCLUDE_PATH}
+	${TBB_INCLUDE_PATH}
 )
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
 

--- a/src/modules/dmx/CMakeLists.txt
+++ b/src/modules/dmx/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required (VERSION 3.16)
+project (dmx)
+
+set(SOURCES
+		consumer/dmx_consumer.cpp
+
+		dmx.cpp
+)
+set(HEADERS
+		consumer/dmx_consumer.h
+
+		dmx.h
+)
+
+add_library(dmx ${SOURCES} ${HEADERS})
+target_compile_features(dmx PRIVATE cxx_std_14)
+target_include_directories(dmx PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+)
+configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
+
+set_target_properties(dmx PROPERTIES FOLDER modules)
+source_group(sources\\consumer consumer/*)
+source_group(sources ./*)
+
+target_link_libraries(dmx common core)
+
+if(MSVC)
+	target_link_libraries(
+		dmx
+		common
+		core
+	)
+else()
+	target_link_libraries(
+		dmx
+		common
+		core
+	)
+endif()
+
+casparcg_add_include_statement("modules/dmx/dmx.h")
+casparcg_add_init_statement("dmx::init" "dmx")
+casparcg_add_uninit_statement("dmx::uninit")
+casparcg_add_module_project("dmx")

--- a/src/modules/dmx/CMakeLists.txt
+++ b/src/modules/dmx/CMakeLists.txt
@@ -4,10 +4,14 @@ project (dmx)
 set(SOURCES
 		consumer/dmx_consumer.cpp
 
+		util/artnet_send.cpp
+
 		dmx.cpp
 )
 set(HEADERS
 		consumer/dmx_consumer.h
+
+		util/artnet_send.h
 
 		dmx.h
 )
@@ -23,6 +27,7 @@ configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_D
 
 set_target_properties(dmx PROPERTIES FOLDER modules)
 source_group(sources\\consumer consumer/*)
+source_group(sources\\util util/*)
 source_group(sources ./*)
 
 target_link_libraries(dmx common core)

--- a/src/modules/dmx/consumer/dmx_consumer.cpp
+++ b/src/modules/dmx/consumer/dmx_consumer.cpp
@@ -17,6 +17,7 @@
 #include <common/log.h>
 #include <common/param.h>
 #include <common/utf.h>
+#include <common/ptree.h>
 
 #include <core/consumer/frame_consumer.h>
 #include <core/frame/frame.h>
@@ -25,70 +26,153 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <boost/locale/encoding_utf.hpp>
+#include <cmath>
 #include <utility>
 #include <vector>
 
+#define M_PI           3.14159265358979323846  /* pi */
+
 namespace caspar {
     namespace dmx {
+
+        enum FixtureType {
+            DIMMER = 1,
+            RGB = 3,
+            RGBW = 4,
+        };
+
+        struct point {
+                float x;
+                float y;
+        };
+
+        struct rect {
+                point p1;
+                point p2;
+                point p3;
+                point p4;
+        };
+
+        struct computed_fixture {
+            FixtureType type;
+            unsigned short address;
+
+            rect rect;
+        };
+
+        struct color {
+            std::uint8_t r;
+            std::uint8_t g;
+            std::uint8_t b;
+        };
+
+
+        struct box {
+                float x;
+                float y;
+
+                float width;
+                float height;
+
+                float rotation; // degrees
+        };
+
+        struct fixture {
+            FixtureType type;
+            unsigned short startAddress; // DMX address of the first channel in the fixture
+            unsigned short fixtureCount; // number of fixtures in the chain, dividing along the width
+
+            box box;
+        };
 
         struct configuration
         {
             int universe = 0;
             std::wstring host = L"127.0.0.1";
             unsigned short port = 6454;
+
+            int refreshRate = 30;
+
+            std::vector<fixture> fixtures;
         };
 
         struct dmx_consumer : public core::frame_consumer
         {
 
-            const std::wstring      host_;
-            const unsigned short      port_;
-            const int      universe_;
+            const configuration config;
+            std::vector<computed_fixture> computed_fixtures;
 
          public:
                 // frame_consumer
 
-                dmx_consumer(configuration config)
-                    : universe_(config.universe)
-                    , host_(std::move(config.host))
-                    , port_(config.port)
+                explicit dmx_consumer(configuration config)
+                    : config(std::move(config))
                 {
-
+                    compute_fixtures();
+                    memset(dmx_data, 0, 512);
                 }
 
 
-                void initialize(const core::video_format_desc& /*format_desc*/, int /*channel_index*/) override {}
+                void initialize(const core::video_format_desc& /*format_desc*/, int /*channel_index*/) override {
+                    thread_ = std::thread([this] {
+                        auto port = config.port;
+                        auto host = config.host;
+
+                        auto universe = config.universe;
+
+                        try {
+                            auto last_send = std::chrono::system_clock::now();
+                            while (!abort_request_) {
+                                auto now = std::chrono::system_clock::now();
+                                std::chrono::duration<double> elapsed_seconds = now - last_send;
+
+                                long long time = 1000 / config.refreshRate;
+                                if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_seconds).count() > time) {
+                                    send_dmx_data(port, host, universe, dmx_data, 512);
+                                    last_send = now;
+                                }
+                            }
+                        } catch (...) {
+                            CASPAR_LOG_CURRENT_EXCEPTION();
+                        }
+                    });
+                }
+
+                ~dmx_consumer()
+                {
+                    abort_request_ = true;
+                    if (thread_.joinable()) {
+                            thread_.join();
+                    }
+                }
 
                 std::future<bool> send(core::video_field field, core::const_frame frame) override
                 {
-                    auto port = port_;
-                    auto host = host_;
-
-                    auto universe = universe_;
-
-                    std::thread async([frame, port, host, universe] {
+                    std::thread async([frame, this] {
                         try {
-                            array<const std::uint8_t> values = frame.image_data(0);
-                            const std::uint8_t* value_ptr = values.data();
-                            std::vector<std::uint8_t> colors;
+                            for (auto computed_fixture : computed_fixtures) {
+                                auto color = average_color(frame, computed_fixture.rect);
+                                uint8_t* ptr = dmx_data + computed_fixture.address;
 
-                            for (int i = 0; i < 10; i++) {
-                                const std::uint8_t* base_ptr = value_ptr + i * 4;
-
-                                const std::uint8_t* r_ptr = base_ptr + 0;
-                                const std::uint8_t* g_ptr = base_ptr + 1;
-                                const std::uint8_t* b_ptr = base_ptr + 2;
-
-                                std::uint8_t r = *r_ptr;
-                                std::uint8_t g = *g_ptr;
-                                std::uint8_t b = *b_ptr;
-
-                                colors.push_back(r);
-                                colors.push_back(g);
-                                colors.push_back(b);
+                                switch (computed_fixture.type) {
+                                    case FixtureType::DIMMER:
+                                        ptr[0] = (color.r + color.g + color.b) / 3;
+                                        break;
+                                    case FixtureType::RGB:
+                                        ptr[0] = color.r;
+                                        ptr[1] = color.g;
+                                        ptr[2] = color.b;
+                                        break;
+                                    case FixtureType::RGBW:
+                                        uint8_t w = std::min(std::min(color.r, color.g), color.b);
+                                        ptr[0] = color.r - w;
+                                        ptr[1] = color.g - w;
+                                        ptr[2] = color.b - w;
+                                        ptr[3] = w;
+                                        break;
+                                }
                             }
-
-                            send_dmx_data(port, host, universe, colors);
                         } catch (...) {
                             CASPAR_LOG_CURRENT_EXCEPTION();
                         }
@@ -109,22 +193,269 @@ namespace caspar {
                     core::monitor::state state;
                     return state;
                 }
+
+         private:
+
+                std::thread       thread_;
+                std::atomic<bool> abort_request_{false};
+
+                uint8_t dmx_data[512];
+
+                void compute_fixtures() {
+                    computed_fixtures.clear();
+                    for (auto fixture : config.fixtures) {
+                        for (int i = 0; i < fixture.fixtureCount; i++) {
+                            computed_fixture computed_fixture{};
+                            computed_fixture.type = fixture.type;
+                            computed_fixture.address = fixture.startAddress + i * fixture.type;
+
+                            computed_fixture.rect = compute_rect(fixture.box, i, fixture.fixtureCount);
+                            computed_fixtures.push_back(computed_fixture);
+                        }
+                    }
+                }
+
+                static rect compute_rect(box box, int index, int count)
+                {
+                    auto f_count = (float) count;
+                    auto f_index = (float) index;
+
+                    float x = box.x;
+                    float y = box.y;
+
+                    float width  = box.width;
+                    float height = box.height;
+
+                    float rotation = box.rotation;
+
+                    float angle = M_PI * rotation / 180.0f;
+
+                    float dx = width / (2 * f_count);
+                    float dy = height / 2.0f;
+
+                    float sin_ = sin(angle);
+                    float cos_ = cos(angle);
+
+                    float od = (2 * f_index - f_count + 1) * dx;
+
+                    float ox = x + od * cos_;
+                    float oy = y + od * sin_;
+
+                    point p1 {
+                            ox + -dx *  cos_ + -dy * -sin_,
+                            oy + -dx *  sin_ + -dy *  cos_,
+                    };
+
+                    point p2 {
+                            ox +  dx *  cos_ + -dy * -sin_,
+                            oy +  dx *  sin_ + -dy *  cos_,
+                    };
+
+                    point p3 {
+                            ox +  dx *  cos_ +  dy * -sin_,
+                            oy +  dx *  sin_ +  dy *  cos_,
+                    };
+
+                    point p4 {
+                            ox + -dx *  cos_ +  dy * -sin_,
+                            oy + -dx *  sin_ +  dy *  cos_,
+                    };
+
+                    rect rect {
+                            p1,
+                            p2,
+                            p3,
+                            p4
+                    };
+
+                    return rect;
+                }
+
+                static color average_color(const core::const_frame& frame, rect& rect) {
+                    int width = (int) frame.width();
+                    int height = (int) frame.height();
+
+                    float y1 = rect.p1.y;
+                    float y2 = rect.p2.y;
+                    float y3 = rect.p3.y;
+                    float y4 = rect.p4.y;
+
+                    float x_values[4];
+                    float y_values[] = {
+                            y1,
+                            y2,
+                            y3,
+                            y4
+                    };
+
+                    std::sort(std::begin(y_values), std::end(y_values));
+
+                    for (int i = 0; i < 4;) {
+                        int c = i;
+
+                        if (y1 == y_values[i]) {
+                            x_values[i] = rect.p1.x;
+                            i++;
+                        }
+                        if (i >= 4) break;
+
+                        if (y2 == y_values[i]) {
+                            x_values[i] = rect.p2.x;
+                            i++;
+                        }
+                        if (i >= 4) break;
+
+                        if (y3 == y_values[i]) {
+                            x_values[i] = rect.p3.x;
+                            i++;
+                        }
+                        if (i >= 4) break;
+
+                        if (y4 == y_values[i]) {
+                            x_values[i] = rect.p4.x;
+                            i++;
+                        }
+                        if (c == i) return color{0, 0, 0}; // should never happen, but prevents infinite loop in case of the impossible
+                    }
+
+                    const int indices[3][4] = {
+                        {0, 1, 0, 2},
+                        {0, 2, 1, 3},
+                        {1, 3, 2, 3},
+                    };
+
+                    int y_min = std::max(0, std::min(height - 1, (int) y_values[0]));
+                    int y_max = std::max(0, std::min(height - 1, (int) y_values[3]));
+
+                    const array<const std::uint8_t>& values = frame.image_data(0);
+                    const std::uint8_t* value_ptr = values.data();
+
+                    unsigned long long tr = 0;
+                    unsigned long long tg = 0;
+                    unsigned long long tb = 0;
+
+                    unsigned long long count = 0;
+
+                    for (int y = y_min; y <= y_max; y++) {
+                        int index = 0;
+                        if (y >= (int) y_values[1]) index = 1;
+                        if (y >= (int) y_values[2]) index = 2;
+
+                        float ax1 = x_values[indices[index][0]];
+                        float ay1 = y_values[indices[index][0]];
+
+                        float bx1 = x_values[indices[index][1]];
+                        float by1 = y_values[indices[index][1]];
+
+                        float ax2 = x_values[indices[index][2]];
+                        float ay2 = y_values[indices[index][2]];
+
+                        float bx2 = x_values[indices[index][3]];
+                        float by2 = y_values[indices[index][3]];
+
+                        float d1 = (bx1 - ax1) / (by1 - ay1);
+                        float d2 = (bx2 - ax2) / (by2 - ay2);
+
+                        auto x1 = std::max(0, std::min(width - 1, (int) (ax1 + ((float) y - ay1) * d1)));
+                        auto x2 = std::max(0, std::min(width - 1, (int) (ax2 + ((float) y - ay2) * d2)));
+
+                        int min_x = std::min(x1, x2);
+                        int max_x = std::max(x1, x2);
+
+                        for (int x = min_x; x <= max_x; x++) {
+                            int pos = y * width + x;
+                            const std::uint8_t* base_ptr = value_ptr + pos * 4;
+
+                            float a = (float) base_ptr[3] / 255.0f;
+
+                            float r = (float) base_ptr[2] * a;
+                            float g = (float) base_ptr[1] * a;
+                            float b = (float) base_ptr[0] * a;
+
+                            tr += (unsigned long long) (r);
+                            tg += (unsigned long long) (g);
+                            tb += (unsigned long long) (b);
+
+                            count++;
+                        }
+                    }
+
+                    color c {
+                        (std::uint8_t) (tr / count),
+                        (std::uint8_t) (tg / count),
+                        (std::uint8_t) (tb / count)
+                    };
+
+                    return c;
+                }
         };
+
+        std::vector<fixture> get_fixtures_ptree(const boost::property_tree::wptree& ptree)
+        {
+                std::vector<fixture> fixtures;
+
+                using boost::property_tree::wptree;
+
+                for (auto& xml_channel : ptree | witerate_children(L"fixtures") | welement_context_iteration) {
+                        ptree_verify_element_name(xml_channel, L"fixture");
+
+                        fixture f {
+
+                        };
+
+                        int startAddress = xml_channel.second.get(L"start-address", 0);
+                        if (startAddress < 1) throw std::runtime_error("Fixture start address must be specified");
+
+                        f.startAddress = startAddress - 1;
+
+                        int fixtureCount = xml_channel.second.get(L"fixture-count", -1);
+                        if (fixtureCount < 0) throw std::runtime_error("Fixture count must be specified");
+
+                        f.fixtureCount = fixtureCount;
+
+                        std::wstring type = xml_channel.second.get(L"type", L"");
+                        if (type.empty()) throw std::runtime_error("Fixture type must be specified, available types: DIMMER, RGB, RGBW");
+                        if (boost::iequals(type, L"DIMMER")) {
+                            f.type = FixtureType::DIMMER;
+                        } else if (boost::iequals(type, L"RGB")) {
+                            f.type = FixtureType::RGB;
+                        } else if (boost::iequals(type, L"RGBW")) {
+                            f.type = FixtureType::RGBW;
+                        } else {
+                            throw std::runtime_error("Unknown fixture type: " + boost::locale::conv::utf_to_utf<char>(type));
+                        }
+
+                        box b {};
+
+                        auto x = xml_channel.second.get(L"x", 0.0f);
+                        auto y = xml_channel.second.get(L"y", 0.0f);
+
+                        b.x = x;
+                        b.y = y;
+
+                        auto width = xml_channel.second.get(L"width", 0.0f);
+                        auto height = xml_channel.second.get(L"height", 0.0f);
+
+                        b.width = width;
+                        b.height = height;
+
+                        auto rotation = xml_channel.second.get(L"rotation", 0.0f);
+
+                        b.rotation = rotation;
+
+                        f.box = b;
+
+                        fixtures.push_back(f);
+                }
+
+                return fixtures;
+        }
 
         spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                              const core::video_format_repository& format_repository,
                                                              const std::vector<spl::shared_ptr<core::video_channel>>& channels)
         {
-           if (params.empty() || !boost::iequals(params.at(0), L"DMX"))
-               return core::frame_consumer::empty();
-
-           configuration config;
-
-           config.universe     = get_param(L"UNIVERSE", params, 0);
-           config.host         = get_param(L"HOST", params, L"");
-           config.port         = get_param(L"PORT", params, 0);
-
-           return spl::make_shared<dmx_consumer>(config);
+            return core::frame_consumer::empty(); // TODO implement
         }
 
         spl::shared_ptr<core::frame_consumer> create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
@@ -136,6 +467,9 @@ namespace caspar {
            config.universe     = ptree.get(L"universe", config.universe);
            config.host         = ptree.get(L"host", config.host);
            config.port         = ptree.get(L"port", config.port);
+           config.refreshRate  = ptree.get(L"refresh-rate", config.refreshRate);
+
+           config.fixtures     = get_fixtures_ptree(ptree);
 
            return spl::make_shared<dmx_consumer>(config);
         }

--- a/src/modules/dmx/consumer/dmx_consumer.cpp
+++ b/src/modules/dmx/consumer/dmx_consumer.cpp
@@ -1,0 +1,107 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+ */
+
+
+#include "dmx_consumer.h"
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#if defined(_MSC_VER)
+#include <windows.h>
+#endif
+
+#include <common/array.h>
+#include <common/env.h>
+#include <common/except.h>
+#include <common/future.h>
+#include <common/log.h>
+#include <common/utf.h>
+
+#include <core/consumer/frame_consumer.h>
+#include <core/frame/frame.h>
+#include <core/video_format.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace caspar {
+    namespace dmx {
+
+        struct dmx_consumer : public core::frame_consumer
+        {
+
+         public:
+                // frame_consumer
+
+                explicit dmx_consumer()
+                {
+                }
+
+                void initialize(const core::video_format_desc& /*format_desc*/, int /*channel_index*/) override {}
+
+                std::future<bool> send(core::video_field field, core::const_frame frame) override
+                {
+                    std::thread async([frame, filename] {
+                        try {
+                            array<const std::uint8_t> values = frame.image_data(0);
+                            vector<string> colors;
+
+                            for (int i = 0; i < 10; i++) {
+                                uint8_t r = values[i * 4 + 0];
+                                uint8_t g = values[i * 4 + 1];
+                                uint8_t b = values[i * 4 + 2];
+
+                                int value = (r << 16) | (g << 8) | b;
+
+                                std::stringstream ss;
+                                ss << "#";
+                                ss << std::hex << value;
+
+                                colors.push_back(ss.str());
+                            }
+
+                            string color_str = boost::join(colors, L" ");
+                            CASPAR_LOG(info) << print() << L" Sending " << color_str;
+
+                            // TODO: use colors to output dmx data
+                        } catch (...) {
+                            CASPAR_LOG_CURRENT_EXCEPTION();
+                        }
+                    });
+                    async.detach();
+
+                    return make_ready_future(false);
+                }
+
+                std::wstring print() const override { return L"dmx[]"; }
+
+                std::wstring name() const override { return L"dmx"; }
+
+                int index() const override { return 1337; }
+
+                core::monitor::state state() const override
+                {
+
+                }
+        };
+
+        spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
+                                                             const core::video_format_repository& format_repository,
+                                                             const std::vector<spl::shared_ptr<core::video_channel>>& channels)
+        {
+           if (params.empty() || !boost::iequals(params.at(0), L"DMX"))
+               return core::frame_consumer::empty();
+
+           return spl::make_shared<dmx_consumer>();
+        }
+
+    }
+} // namespace caspar::dmx

--- a/src/modules/dmx/consumer/dmx_consumer.cpp
+++ b/src/modules/dmx/consumer/dmx_consumer.cpp
@@ -9,9 +9,10 @@
 
 #include "dmx_consumer.h"
 
+#undef NOMINMAX
+// ^^ This is needed to avoid a conflict between boost asio and other header files defining NOMINMAX
+
 #include <common/array.h>
-#include <common/env.h>
-#include <common/except.h>
 #include <common/future.h>
 #include <common/log.h>
 #include <common/param.h>
@@ -24,7 +25,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>
 
-#include <algorithm>
 #include <utility>
 #include <vector>
 
@@ -35,14 +35,14 @@ namespace caspar {
         {
             int universe = 0;
             std::wstring host = L"127.0.0.1";
-            int port = 6454;
+            unsigned short port = 6454;
         };
 
         struct dmx_consumer : public core::frame_consumer
         {
 
             const std::wstring      host_;
-            const int      port_;
+            const unsigned short      port_;
             const int      universe_;
 
          public:

--- a/src/modules/dmx/consumer/dmx_consumer.cpp
+++ b/src/modules/dmx/consumer/dmx_consumer.cpp
@@ -58,7 +58,7 @@ namespace caspar {
             FixtureType type;
             unsigned short address;
 
-            rect rect;
+            rect rectangle;
         };
 
         struct color {
@@ -152,7 +152,7 @@ namespace caspar {
                     std::thread async([frame, this] {
                         try {
                             for (auto computed_fixture : computed_fixtures) {
-                                auto color = average_color(frame, computed_fixture.rect);
+                                auto color = average_color(frame, computed_fixture.rectangle);
                                 uint8_t* ptr = dmx_data + computed_fixture.address;
 
                                 switch (computed_fixture.type) {
@@ -209,7 +209,7 @@ namespace caspar {
                             computed_fixture.type = fixture.type;
                             computed_fixture.address = fixture.startAddress + i * fixture.type;
 
-                            computed_fixture.rect = compute_rect(fixture.fixtureBox, i, fixture.fixtureCount);
+                            computed_fixture.rectangle = compute_rect(fixture.fixtureBox, i, fixture.fixtureCount);
                             computed_fixtures.push_back(computed_fixture);
                         }
                     }
@@ -271,14 +271,14 @@ namespace caspar {
                     return rectangle;
                 }
 
-                static color average_color(const core::const_frame& frame, rect& rect) {
+                static color average_color(const core::const_frame& frame, rect& rectangle) {
                     int width = (int) frame.width();
                     int height = (int) frame.height();
 
-                    float y1 = rect.p1.y;
-                    float y2 = rect.p2.y;
-                    float y3 = rect.p3.y;
-                    float y4 = rect.p4.y;
+                    float y1 = rectangle.p1.y;
+                    float y2 = rectangle.p2.y;
+                    float y3 = rectangle.p3.y;
+                    float y4 = rectangle.p4.y;
 
                     float x_values[4];
                     float y_values[] = {
@@ -294,25 +294,25 @@ namespace caspar {
                         int c = i;
 
                         if (y1 == y_values[i]) {
-                            x_values[i] = rect.p1.x;
+                            x_values[i] = rectangle.p1.x;
                             i++;
                         }
                         if (i >= 4) break;
 
                         if (y2 == y_values[i]) {
-                            x_values[i] = rect.p2.x;
+                            x_values[i] = rectangle.p2.x;
                             i++;
                         }
                         if (i >= 4) break;
 
                         if (y3 == y_values[i]) {
-                            x_values[i] = rect.p3.x;
+                            x_values[i] = rectangle.p3.x;
                             i++;
                         }
                         if (i >= 4) break;
 
                         if (y4 == y_values[i]) {
-                            x_values[i] = rect.p4.x;
+                            x_values[i] = rectangle.p4.x;
                             i++;
                         }
                         if (c == i) return color{0, 0, 0}; // should never happen, but prevents infinite loop in case of the impossible

--- a/src/modules/dmx/consumer/dmx_consumer.cpp
+++ b/src/modules/dmx/consumer/dmx_consumer.cpp
@@ -83,7 +83,7 @@ namespace caspar {
             unsigned short startAddress; // DMX address of the first channel in the fixture
             unsigned short fixtureCount; // number of fixtures in the chain, dividing along the width
 
-            box box;
+            box fixtureBox;
         };
 
         struct configuration
@@ -92,7 +92,7 @@ namespace caspar {
             std::wstring host = L"127.0.0.1";
             unsigned short port = 6454;
 
-            int refreshRate = 30;
+            int refreshRate = 10;
 
             std::vector<fixture> fixtures;
         };
@@ -209,24 +209,24 @@ namespace caspar {
                             computed_fixture.type = fixture.type;
                             computed_fixture.address = fixture.startAddress + i * fixture.type;
 
-                            computed_fixture.rect = compute_rect(fixture.box, i, fixture.fixtureCount);
+                            computed_fixture.rect = compute_rect(fixture.fixtureBox, i, fixture.fixtureCount);
                             computed_fixtures.push_back(computed_fixture);
                         }
                     }
                 }
 
-                static rect compute_rect(box box, int index, int count)
+                static rect compute_rect(box fixtureBox, int index, int count)
                 {
                     auto f_count = (float) count;
                     auto f_index = (float) index;
 
-                    float x = box.x;
-                    float y = box.y;
+                    float x = fixtureBox.x;
+                    float y = fixtureBox.y;
 
-                    float width  = box.width;
-                    float height = box.height;
+                    float width  = fixtureBox.width;
+                    float height = fixtureBox.height;
 
-                    float rotation = box.rotation;
+                    float rotation = fixtureBox.rotation;
 
                     float angle = M_PI * rotation / 180.0f;
 
@@ -261,14 +261,14 @@ namespace caspar {
                             oy + -dx *  sin_ +  dy *  cos_,
                     };
 
-                    rect rect {
+                    rect rectangle {
                             p1,
                             p2,
                             p3,
                             p4
                     };
 
-                    return rect;
+                    return rectangle;
                 }
 
                 static color average_color(const core::const_frame& frame, rect& rect) {
@@ -443,7 +443,7 @@ namespace caspar {
 
                         b.rotation = rotation;
 
-                        f.box = b;
+                        f.fixtureBox = b;
 
                         fixtures.push_back(f);
                 }

--- a/src/modules/dmx/consumer/dmx_consumer.cpp
+++ b/src/modules/dmx/consumer/dmx_consumer.cpp
@@ -49,15 +49,27 @@ namespace caspar {
 
                 std::future<bool> send(core::video_field field, core::const_frame frame) override
                 {
-                    std::thread async([frame, filename] {
+                    std::thread async([frame] {
                         try {
                             array<const std::uint8_t> values = frame.image_data(0);
-                            vector<string> colors;
+                            const std::uint8_t* value_ptr = values.data();
+                            std::vector<std::string> colors;
+                            std::vector<std::uint8_t> colors_dmx;
 
                             for (int i = 0; i < 10; i++) {
-                                uint8_t r = values[i * 4 + 0];
-                                uint8_t g = values[i * 4 + 1];
-                                uint8_t b = values[i * 4 + 2];
+                                const std::uint8_t* base_ptr = value_ptr + i * 4;
+
+                                const std::uint8_t* r_ptr = base_ptr + 0;
+                                const std::uint8_t* g_ptr = base_ptr + 1;
+                                const std::uint8_t* b_ptr = base_ptr + 2;
+
+                                std::uint8_t r = *r_ptr;
+                                std::uint8_t g = *g_ptr;
+                                std::uint8_t b = *b_ptr;
+
+                                colors_dmx.push_back(r);
+                                colors_dmx.push_back(g);
+                                colors_dmx.push_back(b);
 
                                 int value = (r << 16) | (g << 8) | b;
 
@@ -68,10 +80,10 @@ namespace caspar {
                                 colors.push_back(ss.str());
                             }
 
-                            string color_str = boost::join(colors, L" ");
-                            CASPAR_LOG(info) << print() << L" Sending " << color_str;
+                            std::string color_str = boost::join(colors, L" ");
+                            CASPAR_LOG(info) << L" Sending " << color_str;
 
-                            // TODO: use colors to output dmx data
+                            send_dmx_data(6454, "127.0.0.1", 0, colors_dmx);
                         } catch (...) {
                             CASPAR_LOG_CURRENT_EXCEPTION();
                         }
@@ -89,7 +101,8 @@ namespace caspar {
 
                 core::monitor::state state() const override
                 {
-
+                    core::monitor::state state;
+                    return state;
                 }
         };
 

--- a/src/modules/dmx/consumer/dmx_consumer.h
+++ b/src/modules/dmx/consumer/dmx_consumer.h
@@ -26,5 +26,9 @@ namespace caspar {
                        const core::video_format_repository&                     format_repository,
                        const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
+        spl::shared_ptr<core::frame_consumer>
+        create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
+                                                                            const core::video_format_repository&              format_repository,
+                                                                            std::vector<spl::shared_ptr<core::video_channel>> channels);
     }
 } // namespace caspar::dmx

--- a/src/modules/dmx/consumer/dmx_consumer.h
+++ b/src/modules/dmx/consumer/dmx_consumer.h
@@ -1,0 +1,28 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+ */
+
+
+#pragma once
+
+#include <common/memory.h>
+
+#include <core/consumer/frame_consumer.h>
+
+#include <string>
+#include <vector>
+
+namespace caspar {
+    namespace dmx {
+
+        spl::shared_ptr<core::frame_consumer>
+        create_consumer(const std::vector<std::wstring>&                         params,
+                       const core::video_format_repository&                     format_repository,
+                       const std::vector<spl::shared_ptr<core::video_channel>>& channels);
+
+    }
+} // namespace caspar::dmx

--- a/src/modules/dmx/consumer/dmx_consumer.h
+++ b/src/modules/dmx/consumer/dmx_consumer.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "../util/artnet_send.h"
+
 namespace caspar {
     namespace dmx {
 

--- a/src/modules/dmx/dmx.cpp
+++ b/src/modules/dmx/dmx.cpp
@@ -24,6 +24,7 @@ namespace caspar {
             // TODO: Initialise DMX connection
 
             dependencies.consumer_registry->register_consumer_factory(L"DMX Consumer", create_consumer);
+            dependencies.consumer_registry->register_preconfigured_consumer_factory(L"dmx", create_preconfigured_consumer);
         }
 
         void uninit() {

--- a/src/modules/dmx/dmx.cpp
+++ b/src/modules/dmx/dmx.cpp
@@ -1,0 +1,34 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+*/
+
+#include "dmx.h"
+
+#define WIN32_LEAN_AND_MEAN
+
+#include "consumer/dmx_consumer.h"
+
+#include <core/consumer/frame_consumer.h>
+
+#include <common/utf.h>
+
+namespace caspar {
+    namespace dmx {
+
+        void init(const core::module_dependencies& dependencies)
+        {
+            // TODO: Initialise DMX connection
+
+            dependencies.consumer_registry->register_consumer_factory(L"DMX Consumer", create_consumer);
+        }
+
+        void uninit() {
+           // TODO: Remove DMX connection
+        }
+
+    }
+} // namespace caspar::dmx

--- a/src/modules/dmx/dmx.h
+++ b/src/modules/dmx/dmx.h
@@ -1,0 +1,22 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+ */
+
+
+#pragma once
+
+#include <core/module_dependencies.h>
+
+namespace caspar {
+    namespace dmx {
+
+        void init(const core::module_dependencies& dependencies);
+        void uninit();
+
+    }
+} // namespace caspar::dmx
+

--- a/src/modules/dmx/packages.config
+++ b/src/modules/dmx/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.67.0.0" targetFramework="native" />
+</packages>

--- a/src/modules/dmx/util/artnet_send.cpp
+++ b/src/modules/dmx/util/artnet_send.cpp
@@ -17,7 +17,7 @@
 namespace caspar {
     namespace dmx {
 
-        void send_dmx_data(int port, const std::wstring& host, int universe, std::vector<std::uint8_t> data) {
+        void send_dmx_data(unsigned short port, const std::wstring& host, int universe, std::vector<std::uint8_t> data) {
             size_t length = data.size();
             if (length > 512 || length % 2 != 0) {
                 // TODO: throw error

--- a/src/modules/dmx/util/artnet_send.cpp
+++ b/src/modules/dmx/util/artnet_send.cpp
@@ -17,13 +17,7 @@
 namespace caspar {
     namespace dmx {
 
-        void send_dmx_data(unsigned short port, const std::wstring& host, int universe, std::vector<std::uint8_t> data) {
-            size_t length = data.size();
-            if (length > 512 || length % 2 != 0) {
-                // TODO: throw error
-                return;
-            }
-
+        void send_dmx_data(unsigned short port, const std::wstring& host, int universe, const std::uint8_t* data, size_t length) {
             std::uint8_t hUni = (universe >> 8) & 0xff;
             std::uint8_t lUni = universe & 0xff;
 
@@ -52,7 +46,7 @@ namespace caspar {
             boost::asio::ip::udp::endpoint remote_endpoint;
 
             socket.open(boost::asio::ip::udp::v4());
-            
+
             std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converterX;
             std::string host_ = converterX.to_bytes(host);
 
@@ -62,6 +56,17 @@ namespace caspar {
             socket.send_to(boost::asio::buffer(buffer), remote_endpoint, 0, err);
 
             socket.close();
+        }
+
+        void send_dmx_data(unsigned short port, const std::wstring& host, int universe, std::vector<std::uint8_t> data) {
+            size_t length = data.size();
+
+            std::uint8_t buffer[512];
+            memset(buffer, 0, 512);
+
+            for (int i = 0; i < length; i++) buffer[i] = data[i];
+
+            send_dmx_data(port, host, universe, buffer, length);
         }
     }
 } // namespace caspar::dmx

--- a/src/modules/dmx/util/artnet_send.cpp
+++ b/src/modules/dmx/util/artnet_send.cpp
@@ -8,11 +8,10 @@
 
 #include "artnet_send.h"
 
-#include <locale>
+#include <common/utf.h>
+
 #include <string>
 #include <vector>
-
-#include <codecvt>
 
 namespace caspar {
     namespace dmx {
@@ -47,9 +46,7 @@ namespace caspar {
 
             socket.open(boost::asio::ip::udp::v4());
 
-            std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converterX;
-            std::string host_ = converterX.to_bytes(host);
-
+            std::string host_ = u8(host);
             remote_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(host_), port);
 
             boost::system::error_code err;

--- a/src/modules/dmx/util/artnet_send.cpp
+++ b/src/modules/dmx/util/artnet_send.cpp
@@ -8,20 +8,17 @@
 
 #include "artnet_send.h"
 
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#if defined(_MSC_VER)
-#include <windows.h>
-#endif
-
+#include <locale>
 #include <string>
 #include <vector>
+
+#include <codecvt>
 
 namespace caspar {
     namespace dmx {
 
-        void send_dmx_data(int port, std::string host, int universe, std::vector<std::uint8_t> data) {
-            int length = data.size();
+        void send_dmx_data(int port, const std::wstring& host, int universe, std::vector<std::uint8_t> data) {
+            size_t length = data.size();
             if (length > 512 || length % 2 != 0) {
                 // TODO: throw error
                 return;
@@ -55,8 +52,11 @@ namespace caspar {
             boost::asio::ip::udp::endpoint remote_endpoint;
 
             socket.open(boost::asio::ip::udp::v4());
+            
+            std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converterX;
+            std::string host_ = converterX.to_bytes(host);
 
-            remote_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(host), port);
+            remote_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(host_), port);
 
             boost::system::error_code err;
             socket.send_to(boost::asio::buffer(buffer), remote_endpoint, 0, err);

--- a/src/modules/dmx/util/artnet_send.h
+++ b/src/modules/dmx/util/artnet_send.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "boost/asio.hpp"
+#include <boost/asio.hpp>
 
 #include <string>
 #include <vector>

--- a/src/modules/dmx/util/artnet_send.h
+++ b/src/modules/dmx/util/artnet_send.h
@@ -1,0 +1,21 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+ */
+
+#pragma once
+
+#include "boost/asio.hpp"
+
+#include <string>
+#include <vector>
+
+namespace caspar {
+    namespace dmx {
+
+        void send_dmx_data(int port, std::string host, int universe, std::vector<uint8_t> data);
+    }
+} // namespace caspar::dmx

--- a/src/modules/dmx/util/artnet_send.h
+++ b/src/modules/dmx/util/artnet_send.h
@@ -16,6 +16,6 @@
 namespace caspar {
     namespace dmx {
 
-        void send_dmx_data(int port, std::string host, int universe, std::vector<uint8_t> data);
+        void send_dmx_data(int port, const std::wstring& host, int universe, std::vector<uint8_t> data);
     }
 } // namespace caspar::dmx

--- a/src/modules/dmx/util/artnet_send.h
+++ b/src/modules/dmx/util/artnet_send.h
@@ -16,6 +16,6 @@
 namespace caspar {
     namespace dmx {
 
-        void send_dmx_data(int port, const std::wstring& host, int universe, std::vector<uint8_t> data);
+        void send_dmx_data(unsigned short port, const std::wstring& host, int universe, std::vector<uint8_t> data);
     }
 } // namespace caspar::dmx

--- a/src/modules/dmx/util/artnet_send.h
+++ b/src/modules/dmx/util/artnet_send.h
@@ -16,6 +16,7 @@
 namespace caspar {
     namespace dmx {
 
+        void send_dmx_data(unsigned short port, const std::wstring& host, int universe, const std::uint8_t* data, size_t length);
         void send_dmx_data(unsigned short port, const std::wstring& host, int universe, std::vector<uint8_t> data);
     }
 } // namespace caspar::dmx

--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -30,7 +30,9 @@ set(SOURCES
 		util/http_request.cpp
 		util/tokenize.cpp
 
+		heartbeat/service.cpp
 )
+
 set(HEADERS
 		amcp/AMCPCommand.h
 		amcp/AMCPCommandQueue.h
@@ -69,6 +71,8 @@ set(HEADERS
 		util/strategy_adapters.h
 		util/http_request.h
 		util/tokenize.h
+
+        heartbeat/service.h
 
 		StdAfx.h
 )

--- a/src/protocol/heartbeat/service.cpp
+++ b/src/protocol/heartbeat/service.cpp
@@ -1,0 +1,112 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+ */
+
+#include "service.h"
+
+using namespace boost::asio::ip;
+
+namespace caspar {
+    namespace protocol {
+        namespace heartbeat {
+            struct service::impl {
+              public:
+                explicit impl(std::shared_ptr<boost::asio::io_service> service)
+                    : service_(std::move(service)),
+                    socket_(*service_, udp::v4())
+                {
+                    socket_.set_option(udp::socket::reuse_address(true));
+                    socket_.set_option(udp::socket::broadcast(true));
+
+                    thread_ = std::thread([this] {
+                        try {
+                            auto last_send = std::chrono::system_clock::now();
+                            while (!abort_request_) {
+                                auto now = std::chrono::system_clock::now();
+                                std::chrono::duration<double> elapsed_seconds = now - last_send;
+
+                                if (elapsed_seconds.count() > 1) {
+                                    send_heartbeat();
+                                    last_send = now;
+                                }
+                            }
+                        } catch (...) {
+                            CASPAR_LOG_CURRENT_EXCEPTION();
+                        }
+                    });
+                }
+
+                ~impl()
+                {
+                    abort_request_ = true;
+                    thread_.join();
+                }
+
+                void send_heartbeat() {
+                    auto remote_endpoint = udp::endpoint(calculateBroadcastAddress(), 3468);
+                    std::string message = "CG " + name_;
+
+                    boost::system::error_code err;
+                    socket_.send_to(boost::asio::buffer(message), remote_endpoint, 0, err);
+
+                    if (err) {
+                        CASPAR_LOG(error) << "Error sending heartbeat: " << err.message();
+                    }
+                }
+
+                void set_name(std::string name) {
+                    name_ = name;
+                }
+
+              private:
+                std::thread       thread_;
+                std::atomic<bool> abort_request_{false};
+
+                std::shared_ptr<boost::asio::io_context> service_;
+                udp::socket socket_;
+
+                std::string name_;
+
+                static address_v4 calculateBroadcastAddress() {
+                    boost::asio::io_context ioContext;
+                    udp::resolver resolver(ioContext);
+
+                    udp::resolver::query query(udp::v4(), host_name(), "");
+                    udp::resolver::iterator it = resolver.resolve(query);
+
+                    while (it != udp::resolver::iterator()) {
+                        udp::endpoint endpoint = *it++;
+                        if (endpoint.address().is_v4()) {
+                            address_v4 address = endpoint.address().to_v4();
+                            address_v4 broadcast = address_v4::broadcast(address, address_v4::netmask(address));
+                            return broadcast;
+                        }
+                    }
+
+                    // Return default broadcast address
+                    return address_v4::broadcast();
+                }
+            };
+
+            service::service(std::shared_ptr<boost::asio::io_service> service) : impl_(new impl(std::move(service))) {
+
+            }
+
+            void service::send_heartbeat() {
+                    impl_->send_heartbeat();
+            }
+
+            void service::set_name(std::string name) {
+                    impl_->set_name(name);
+            }
+
+            service::~service() {
+
+            }
+        }
+    }
+}

--- a/src/protocol/heartbeat/service.h
+++ b/src/protocol/heartbeat/service.h
@@ -1,0 +1,31 @@
+/*
+* Copyright (c) 2023 Eliyah Sundström
+*
+* This file is part of an extension of the CasparCG project
+*
+* Author: Eliyah Sundström eliyah@sundstroem.com
+ */
+
+#pragma once
+
+#include <boost/asio.hpp>
+
+namespace caspar {
+    namespace protocol {
+        namespace heartbeat {
+            class service {
+              public:
+                explicit service(std::shared_ptr<boost::asio::io_service> service);
+                ~service();
+
+                void set_name(std::string name);
+
+              private:
+                struct impl;
+                spl::shared_ptr<impl> impl_;
+
+                void send_heartbeat();
+            };
+        }
+    }
+}

--- a/src/protocol/heartbeat/service.h
+++ b/src/protocol/heartbeat/service.h
@@ -13,18 +13,26 @@
 namespace caspar {
     namespace protocol {
         namespace heartbeat {
+            struct configuration {
+                std::string host;
+                unsigned short port = 3468;
+
+                int delay = 1000;
+            };
+
             class service {
               public:
                 explicit service(std::shared_ptr<boost::asio::io_service> service);
                 ~service();
 
-                void set_name(std::string name);
+                void set_name(const std::string& name);
+                void enable(const configuration& config);
+
+                void send_heartbeat();
 
               private:
                 struct impl;
                 spl::shared_ptr<impl> impl_;
-
-                void send_heartbeat();
             };
         }
     }

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -135,7 +135,12 @@
                 <path>[file|url]</path>
                 <args>[most ffmpeg arguments related to filtering and output codecs]</args>
             </ffmpeg>
-            <dmx></dmx>
+            <dmx>
+                <universe>0</universe>
+
+                <host>127.0.0.1</host>
+                <port>6454</port>
+            </dmx>
         </consumers>
         <producers>
             <producer id="0">AMB LOOP</producer>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -67,12 +67,6 @@
 <ndi>
     <auto-load>false [true|false]</auto-load>
 </ndi>
-<dmx>
-    <universe>0</universe>
-
-    <host>127.0.0.1</host>
-    <port>6454</port>
-</dmx>
 <video-modes>
     <video-mode>
         <id>1024x768p60</id>
@@ -149,6 +143,24 @@
 
                 <host>127.0.0.1</host>
                 <port>6454</port>
+
+                <refresh-rate>30</refresh-rate>
+
+                <fixtures>
+                    <fixture>
+                        <type>RGB</type>
+                        <start-address>1</start-address>
+                        <fixture-count>10</fixture-count>
+
+                        <x>960</x>
+                        <y>540</y>
+
+                        <width>500</width>
+                        <height>100</height>
+
+                        <rotation>0</rotation>
+                    </fixture>
+                </fixtures>
             </dmx>
         </consumers>
         <producers>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -67,6 +67,12 @@
 <ndi>
     <auto-load>false [true|false]</auto-load>
 </ndi>
+<heartbeat>
+    <enabled>true [true|false]</enabled>
+    <delay>1000 [0..]</delay>
+    <port>3468 [1024-65535]</port>
+    <host>[ip-address, leaving it blank will default to the networks broadcast address]</host>
+</heartbeat>
 <video-modes>
     <video-mode>
         <id>1024x768p60</id>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -135,6 +135,7 @@
                 <path>[file|url]</path>
                 <args>[most ffmpeg arguments related to filtering and output codecs]</args>
             </ffmpeg>
+            <dmx></dmx>
         </consumers>
         <producers>
             <producer id="0">AMB LOOP</producer>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
+    <meta>
+        <name>CasparCG Server</name>
+    </meta>
     <paths>
         <media-path>media/</media-path>
         <log-path disable="false">log/</log-path>
@@ -64,6 +67,12 @@
 <ndi>
     <auto-load>false [true|false]</auto-load>
 </ndi>
+<dmx>
+    <universe>0</universe>
+
+    <host>127.0.0.1</host>
+    <port>6454</port>
+</dmx>
 <video-modes>
     <video-mode>
         <id>1024x768p60</id>


### PR DESCRIPTION
I added a DMX consumer that is capable of taking a region of a channel and outputing that onto dmx channels in different forms. It is capable of outputing three modes. These modes are DIMMER, RGB, RGBW, which will average the color in the region and change its colorspace to then output 1, 3, 4 channels on the configured artnet universe starting at the configured start address. I also created a UDP Hearbeat service that lets you configure a name for a caspar server, and it will broadcast that name every second, letting people on the network easier find caspar servers. This is an optional settings and can be turned off, in settings such as public wifis where you don't want to announce the IP of the caspar server. The port and send interval can also be configured.